### PR TITLE
feat: 사용자 한 일 일, 주, 월 집계 기능 구현

### DIFF
--- a/src/main/java/team/bridgers/backend/domain/usertodo/domain/UserTodo.java
+++ b/src/main/java/team/bridgers/backend/domain/usertodo/domain/UserTodo.java
@@ -9,6 +9,7 @@ import team.bridgers.backend.domain.user.domain.User;
 import team.bridgers.backend.global.domain.BaseTimeEntity;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,6 +37,9 @@ public class UserTodo extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private boolean completed = false;
 
+    @Column
+    private LocalDateTime completedAt;
+
     @Builder
     private UserTodo(User user, String task, LocalDate deadLine, Priority priority) {
         this.user = user;
@@ -46,10 +50,12 @@ public class UserTodo extends BaseTimeEntity {
 
     public void complete() {
         this.completed = true;
+        this.completedAt = LocalDateTime.now();
     }
 
     public void uncomplete() {
         this.completed = false;
+        this.completedAt = null;
     }
 
     public void updateUserTodo(String task, LocalDate deadLine, Priority priority) {

--- a/src/main/java/team/bridgers/backend/domain/usertodo/domain/UserTodoRepository.java
+++ b/src/main/java/team/bridgers/backend/domain/usertodo/domain/UserTodoRepository.java
@@ -1,5 +1,6 @@
 package team.bridgers.backend.domain.usertodo.domain;
 
+import org.springframework.data.repository.query.Param;
 import team.bridgers.backend.domain.user.domain.User;
 
 import java.time.LocalDate;
@@ -13,8 +14,14 @@ public interface UserTodoRepository {
 
     List<UserTodo> findAllByUser(User user, String sortBy);
 
-    void deleteByDeadLineBefore(LocalDate deadline);
+    void deleteByDeadLineBeforeAndCompletedFalse(LocalDate deadline);
 
     void delete(UserTodo userTodo);
+
+    List<Object[]> countCompletedTodosByDay(@Param("userId") Long userId);
+
+    List<Object[]> countCompletedTodosByWeek(@Param("userId") Long userId);
+
+    List<Object[]> countCompletedTodosByMonth(@Param("userId") Long userId);
 
 }

--- a/src/main/java/team/bridgers/backend/domain/usertodo/dto/response/CompletedTodoStatsResponse.java
+++ b/src/main/java/team/bridgers/backend/domain/usertodo/dto/response/CompletedTodoStatsResponse.java
@@ -1,0 +1,13 @@
+package team.bridgers.backend.domain.usertodo.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CompletedTodoStatsResponse(
+
+        String period,
+
+        int completedCount
+
+) {
+}

--- a/src/main/java/team/bridgers/backend/domain/usertodo/infrastructure/UserTodoJpaRepository.java
+++ b/src/main/java/team/bridgers/backend/domain/usertodo/infrastructure/UserTodoJpaRepository.java
@@ -2,6 +2,7 @@ package team.bridgers.backend.domain.usertodo.infrastructure;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team.bridgers.backend.domain.user.domain.User;
 import team.bridgers.backend.domain.usertodo.domain.UserTodo;
 
@@ -22,6 +23,27 @@ public interface UserTodoJpaRepository extends JpaRepository<UserTodo, Long> {
 
     List<UserTodo> findAllByUserOrderByDeadLineAsc(User user);
 
-    void deleteByDeadLineBefore(LocalDate deadline);
+    void deleteByDeadLineBeforeAndCompletedFalse(LocalDate deadline);
+
+    @Query("SELECT FUNCTION('DATE', u.completedAt), COUNT(u) " +
+            "FROM UserTodo u " +
+            "WHERE u.user.id = :userId AND u.completed = true AND u.completedAt IS NOT NULL " +
+            "GROUP BY FUNCTION('DATE', u.completedAt) " +
+            "ORDER BY FUNCTION('DATE', u.completedAt)")
+    List<Object[]> countCompletedTodosByDay(@Param("userId") Long userId);
+
+    @Query("SELECT FUNCTION('YEARWEEK', u.completedAt), COUNT(u) " +
+            "FROM UserTodo u " +
+            "WHERE u.user.id = :userId AND u.completed = true AND u.completedAt IS NOT NULL " +
+            "GROUP BY FUNCTION('YEARWEEK', u.completedAt) " +
+            "ORDER BY FUNCTION('YEARWEEK', u.completedAt)")
+    List<Object[]> countCompletedTodosByWeek(@Param("userId") Long userId);
+
+    @Query("SELECT FUNCTION('DATE_FORMAT', u.completedAt, '%Y-%m'), COUNT(u) " +
+            "FROM UserTodo u " +
+            "WHERE u.user.id = :userId AND u.completed = true AND u.completedAt IS NOT NULL " +
+            "GROUP BY FUNCTION('DATE_FORMAT', u.completedAt, '%Y-%m') " +
+            "ORDER BY FUNCTION('DATE_FORMAT', u.completedAt, '%Y-%m')")
+    List<Object[]> countCompletedTodosByMonth(@Param("userId") Long userId);
 
 }

--- a/src/main/java/team/bridgers/backend/domain/usertodo/infrastructure/UserTodoRepositoryImpl.java
+++ b/src/main/java/team/bridgers/backend/domain/usertodo/infrastructure/UserTodoRepositoryImpl.java
@@ -1,6 +1,7 @@
 package team.bridgers.backend.domain.usertodo.infrastructure;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import team.bridgers.backend.domain.user.domain.User;
 import team.bridgers.backend.domain.usertodo.domain.UserTodo;
@@ -37,13 +38,28 @@ public class UserTodoRepositoryImpl implements UserTodoRepository {
     }
 
     @Override
-    public void deleteByDeadLineBefore(LocalDate deadline) {
-        userTodoJpaRepository.deleteByDeadLineBefore(deadline);
+    public void deleteByDeadLineBeforeAndCompletedFalse(LocalDate deadline) {
+        userTodoJpaRepository.deleteByDeadLineBeforeAndCompletedFalse(deadline);
     }
 
     @Override
     public void delete(UserTodo userTodo) {
         userTodoJpaRepository.delete(userTodo);
+    }
+
+    @Override
+    public List<Object[]> countCompletedTodosByDay(@Param("userId") Long userId) {
+        return userTodoJpaRepository.countCompletedTodosByDay(userId);
+    }
+
+    @Override
+    public List<Object[]> countCompletedTodosByWeek(@Param("userId") Long userId) {
+        return userTodoJpaRepository.countCompletedTodosByWeek(userId);
+    }
+
+    @Override
+    public List<Object[]> countCompletedTodosByMonth(@Param("userId") Long userId) {
+        return userTodoJpaRepository.countCompletedTodosByMonth(userId);
     }
 
 }

--- a/src/main/java/team/bridgers/backend/domain/usertodo/presentation/UserTodoController.java
+++ b/src/main/java/team/bridgers/backend/domain/usertodo/presentation/UserTodoController.java
@@ -10,6 +10,8 @@ import team.bridgers.backend.domain.usertodo.dto.request.UserTodoUpdateRequest;
 import team.bridgers.backend.domain.usertodo.dto.response.*;
 import team.bridgers.backend.global.annotation.MemberId;
 
+import java.util.List;
+
 import static org.springframework.http.HttpStatus.CREATED;
 
 @RequiredArgsConstructor
@@ -64,5 +66,15 @@ public class UserTodoController {
         UserTodoDeleteResponse response = userTodoService.deleteUserTodo(userId, userTodoId);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/stats")
+    public ResponseEntity<List<CompletedTodoStatsResponse>> getCompletedStats(
+            @MemberId Long userId,
+            @RequestParam String period
+    ) {
+        List<CompletedTodoStatsResponse> response = userTodoService.getCompletedStats(userId, period);
+        return ResponseEntity.ok(response);
+    }
+
 
 }

--- a/src/main/java/team/bridgers/backend/domain/usertodo/presentation/exception/InvalidPeriodException.java
+++ b/src/main/java/team/bridgers/backend/domain/usertodo/presentation/exception/InvalidPeriodException.java
@@ -1,0 +1,9 @@
+package team.bridgers.backend.domain.usertodo.presentation.exception;
+
+import team.bridgers.backend.global.exception.CustomException;
+
+public class InvalidPeriodException extends CustomException {
+    public InvalidPeriodException() {
+        super(UserTodoExceptionCode.INVALID_PERIOD);
+    }
+}

--- a/src/main/java/team/bridgers/backend/domain/usertodo/presentation/exception/UserTodoExceptionCode.java
+++ b/src/main/java/team/bridgers/backend/domain/usertodo/presentation/exception/UserTodoExceptionCode.java
@@ -5,12 +5,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import team.bridgers.backend.global.exception.ExceptionCode;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @RequiredArgsConstructor
 public enum UserTodoExceptionCode implements ExceptionCode {
-    USER_TODO_NOT_FOUND(NOT_FOUND, "해당 사용자의 할 일을 찾을 수 없습니다.")
+    USER_TODO_NOT_FOUND(NOT_FOUND, "해당 사용자의 할 일을 찾을 수 없습니다."),
+    INVALID_PERIOD(BAD_REQUEST, "지원하지 않는 기간 타입입니다."),
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
### 작업 내용
1. UserTodo 엔티티에 `completedAt` 필드 추가
   - 완료 시각 기록용 필드
   - toggleCompleted() 호출 시 현재 시각 자동 저장
2. 일/주/월별 완료 통계 JPQL 쿼리 추가 (MySQL용)
   - 일별: DATE(completedAt)
   - 주별: YEARWEEK(completedAt)
   - 월별: DATE_FORMAT(completedAt, '%Y-%m')
3. 통계 조회 시 completedAt IS NOT NULL 조건 추가
   - NPE 방지 및 정확한 통계 확보
4. DTO 빌더 방식으로 CompletedTodoStatsResponse 반환

### 기대 효과
- 이제 day/week/month별 완료 통계를 정확히 조회 가능
- 오늘 완료한 일(day) 집계에서 미래(deadLine) 데이터 제외
- 기존 toggleCompleted 로직과 호환, 완료 취소 시 completedAt null 처리

### 참고
- DB: MySQL 기준
